### PR TITLE
Carpentry -> Carpentries

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@ title: "Contributor Code of Conduct"
 ---
 
 As contributors and maintainers of this project,
-we pledge to follow the [Carpentry Code of Conduct][coc].
+we pledge to follow the [The Carpentries Code of Conduct][coc].
 
 Instances of abusive, harassing, or otherwise unacceptable behavior
 may be reported by following our [reporting guidelines][coc-reporting].


### PR DESCRIPTION
I think this is more consistent with [our style guide](https://docs.carpentries.org/topic_folders/communications/resources/style-guide.html#carpentries)

