### PR TITLE
Update trademark ownership statement in license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -69,11 +69,11 @@ SOFTWARE.
 ## Trademark
 
 "The Carpentries", "Software Carpentry", "Data Carpentry", and "Library
-Carpentry" and their respective logos are registered trademarks of [Community
-Initiatives][ci].
+Carpentry" and their respective logos are registered trademarks of [The Carpentries Inc][the-carpentries].
 
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
 [mit-license]: https://opensource.org/licenses/mit-license.html
 [ci]: https://communityin.org/
 [osi]: https://opensource.org
+[the-carpentries]: https://carpentries.org


### PR DESCRIPTION
Since The Carpentries is no longer fiscally-sponsored.