### PR TITLE
update code of conduct and reporting links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -9,5 +9,5 @@ Instances of abusive, harassing, or otherwise unacceptable behavior
 may be reported by following our [reporting guidelines][coc-reporting].
 
 
-[coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html
-[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[coc-reporting]: https://docs.carpentries.org/policies/coc/incident-reporting.html
+[coc]: https://docs.carpentries.org/policies/coc/


### PR DESCRIPTION
This aims to update the default links to the carpentries handbook