### PR TITLE
Add basic devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM carpentries/workbench-docker:latest
+
+RUN Rscript -e 'sandpaper::use_package_cache(prompt = FALSE)'
+
+COPY renv/profiles/lesson-requirements/renv.lock .
+RUN Rscript -e 'renv::restore(prompt = FALSE)'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+    "build": { "dockerfile": "Dockerfile", "context": ".." }
+}


### PR DESCRIPTION
This PR adds a [development container](https://containers.dev/) to make the workbench docker container more visible & easily usable by vscode users, and directly online on GitHub via their [codespaces feature](https://docs.github.com/en/codespaces/about-codespaces/what-are-codespaces).

I am hoping this will resolve some local set up issues we are getting from reviewers of our lessons in Epiverse.

I'm not the best with Docker so I'm happy to revisit if you think it could be improved