### PR TITLE
Update devcontainer with mounts and user specification

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,5 @@
 FROM carpentries/workbench-docker:latest
 
-RUN Rscript -e 'sandpaper::use_package_cache(prompt = FALSE)'
-
-COPY renv/profiles/lesson-requirements/renv.lock .
-RUN Rscript -e 'renv::restore(prompt = FALSE)'
+##  this could be used to run userland scripts e.g.
+##  users could add specific dependencies or configurations
+##  RUN scripts/userland.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,17 @@
 {
-    "build": { "dockerfile": "Dockerfile", "context": ".." }
+    "remoteUser":"rstudio",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/rstudio/lesson,type=bind",
+    "workspaceFolder": "/home/rstudio/lesson",
+    "mounts": [
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/rstudio/.ssh,type=bind,consistency=cached",
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.gnupg,target=/home/rstudio/.gnupg,type=bind,consistency=cached"
+    ],
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "postCreateCommand": {
+        "lesson_deps": "sudo Rscript /home/rstudio/.workbench/setup_lesson_deps.R",
+        "fortify": "Rscript /home/rstudio/.workbench/fortify_renv_cache.R"
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
         "context": ".."
     },
     "postCreateCommand": {
-        "lesson_deps": "sudo Rscript /home/rstudio/.workbench/setup_lesson_deps.R",
+        "pre_echo": "echo 'Installing lesson prerequisites - please wait...'",
+        "lesson_deps": "Rscript /home/rstudio/.workbench/setup_lesson_deps.R",
         "fortify": "Rscript /home/rstudio/.workbench/fortify_renv_cache.R"
     }
 }


### PR DESCRIPTION
Following on from the excellent idea and initial configuration for a [template devcontainer](https://github.com/carpentries/workbench-template-rmd/pull/88) by @Bisaloo, this PR:

- adds mount points for .ssh and .gnupg folders if they exist in a user's home directory
- uses the rstudio user in the container instead of root
- mounts the template/lesson in `/home/rstudio/lesson`
- runs the two scripts already present in the container to set up the lesson's dependencies and R packages